### PR TITLE
add support for dnspython 2.1

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,9 @@
 import pytest
 import localzone
-from dns.zone import UnknownOrigin
+try:
+    from dns.zonefile import UnknownOrigin
+except ImportError:
+    from dns.zone import UnknownOrigin
 
 ZONEFILE = "tests/zonefiles/db.example.com"
 ORIGIN = "example.com."

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 from dns.rdatatype import UnknownRdatatype
+from dns.exception import SyntaxError as DNSSyntaxError
 import pytest
 import localzone
 
@@ -77,7 +78,7 @@ def test_zone_add_record_unknown_type():
 
 def test_zone_add_record_no_content():
     with localzone.manage(ZONEFILE, ORIGIN) as z:
-        with pytest.raises(AttributeError):
+        with pytest.raises((AttributeError, DNSSyntaxError)):
             z.add_record("test", "txt", None)
 
 


### PR DESCRIPTION
dnspython 2.1 exposes the formerly private `dns.zone._MasterReader` as `dns.zonefile.Reader` to be used within a transaction context.

Tested with dnspython 2.1 and 1.16 on Python 3.6 and 3.8.